### PR TITLE
Escape `rank` column to fix MySQL 8.0 login error

### DIFF
--- a/Roseau-Server/src/main/java/org/alexdev/roseau/dao/mysql/MySQLPlayerDao.java
+++ b/Roseau-Server/src/main/java/org/alexdev/roseau/dao/mysql/MySQLPlayerDao.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Lists;
 public class MySQLPlayerDao extends IProcessStorage<PlayerDetails, ResultSet> implements PlayerDao {
 
 	private MySQLDao dao;
-	private String fields = "id, username, password, rank, mission, figure, pool_figure, email, credits, sex, country, badge, birthday, last_online, personal_greeting, tickets";
+	private String fields = "id, username, password, `rank`, mission, figure, pool_figure, email, credits, sex, country, badge, birthday, last_online, personal_greeting, tickets";
 
 	public MySQLPlayerDao(MySQLDao dao) {
 		this.dao = dao;


### PR DESCRIPTION
`rank` became a reserved keyword in MySQL 8.0, causing a syntax error in any SELECT that referenced it unquoted.

This error prevented users from logging into the hotel.