### PR TITLE
Don't close server connection when user gets password wrong

### DIFF
--- a/Roseau-Server/build.gradle
+++ b/Roseau-Server/build.gradle
@@ -40,6 +40,9 @@ dependencies {
 
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-simple
     implementation group: 'org.slf4j', name: 'slf4j-simple', version: '1.7.2'
+
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 
@@ -53,4 +56,8 @@ tasks.shadowJar {
 
 artifacts {
     archives tasks.named("shadowJar")
+}
+
+test {
+    useJUnitPlatform()
 }

--- a/Roseau-Server/src/main/java/org/alexdev/roseau/messages/incoming/LOGIN.java
+++ b/Roseau-Server/src/main/java/org/alexdev/roseau/messages/incoming/LOGIN.java
@@ -5,7 +5,7 @@ import org.alexdev.roseau.game.player.Player;
 import org.alexdev.roseau.game.room.Room;
 import org.alexdev.roseau.log.Log;
 import org.alexdev.roseau.messages.MessageEvent;
-import org.alexdev.roseau.messages.outgoing.SYSTEMBROADCAST;
+import org.alexdev.roseau.messages.outgoing.ERROR;
 import org.alexdev.roseau.server.messages.ClientMessage;
 
 public class LOGIN implements MessageEvent {
@@ -13,8 +13,7 @@ public class LOGIN implements MessageEvent {
 	@Override
 	public void handle(Player player, ClientMessage reader) {
 		if (!(reader.getArgumentAmount() > 1)) {
-			player.send(new SYSTEMBROADCAST("Your username or password was incorrect."));
-			player.getNetwork().close();
+			player.send(new ERROR("Login incorrect"));
 			return;
 		}
 		
@@ -63,9 +62,7 @@ public class LOGIN implements MessageEvent {
 			
 			
 		} else {
-			player.send(new SYSTEMBROADCAST("Your username or password was incorrect."));
-			player.getNetwork().close();
-			return;
+			player.send(new ERROR("Login incorrect"));
 		}
 	}
 }

--- a/Roseau-Server/src/test/java/org/alexdev/roseau/messages/incoming/LOGINTest.java
+++ b/Roseau-Server/src/test/java/org/alexdev/roseau/messages/incoming/LOGINTest.java
@@ -1,0 +1,112 @@
+package org.alexdev.roseau.messages.incoming;
+
+import org.alexdev.roseau.Roseau;
+import org.alexdev.roseau.game.player.PlayerManager;
+import org.alexdev.roseau.messages.outgoing.ERROR;
+import org.alexdev.roseau.server.netty.readers.NettyRequest;
+import org.alexdev.roseau.stubs.GameStub;
+import org.alexdev.roseau.stubs.InMemoryDaoStub;
+import org.alexdev.roseau.stubs.InMemoryPlayerDaoStub;
+import org.alexdev.roseau.stubs.PlayerStub;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class LOGINTest {
+
+    private InMemoryPlayerDaoStub playerDao;
+    private PlayerManager playerManager;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        playerDao = new InMemoryPlayerDaoStub();
+        setRoseauStaticField("dao", new InMemoryDaoStub(playerDao));
+        playerManager = new PlayerManager();
+        setRoseauStaticField("game", new GameStub(playerManager));
+    }
+
+    @Test
+    void tooFewArguments_sendsError() {
+        PlayerStub player = new PlayerStub();
+        NettyRequest request = new NettyRequest("LOGIN", "testuser");
+
+        new LOGIN().handle(player, request);
+
+        assertFalse(player.getDetails().isAuthenticated());
+        assertEquals(1, player.getResponses().size());
+        assertInstanceOf(ERROR.class, player.getResponses().get(0));
+    }
+
+    @Test
+    void userNotFound_sendsError() {
+        PlayerStub player = new PlayerStub();
+        NettyRequest request = new NettyRequest("LOGIN", "unknownuser somepassword");
+
+        new LOGIN().handle(player, request);
+
+        assertFalse(player.getDetails().isAuthenticated());
+        assertEquals(1, player.getResponses().size());
+        assertInstanceOf(ERROR.class, player.getResponses().get(0));
+    }
+
+    @Test
+    void wrongPassword_sendsError() {
+        registerPlayer("testuser", "correctpassword");
+        PlayerStub player = new PlayerStub();
+        NettyRequest request = new NettyRequest("LOGIN", "testuser wrongpassword");
+
+        new LOGIN().handle(player, request);
+
+        assertFalse(player.getDetails().isAuthenticated());
+        assertEquals(1, player.getResponses().size());
+        assertInstanceOf(ERROR.class, player.getResponses().get(0));
+    }
+
+    @Test
+    void correctPassword_authenticatesPlayer() {
+        registerPlayer("testuser", "correctpassword");
+        PlayerStub player = new PlayerStub();
+        NettyRequest request = new NettyRequest("LOGIN", "testuser correctpassword");
+
+        new LOGIN().handle(player, request);
+
+        assertTrue(player.getDetails().isAuthenticated());
+        assertEquals("correctpassword", player.getDetails().getPassword());
+        assertTrue(player.getResponses().isEmpty());
+    }
+
+    @Test
+    void correctPasswordWithDuplicateSession_closesDuplicateSession() {
+        registerPlayer("testuser", "correctpassword");
+        PlayerStub existingPlayer = new PlayerStub(/* connectionId= */ 1);
+        playerDao.login(existingPlayer, "testuser", "correctpassword");
+        playerManager.getPlayers().put(existingPlayer.getDetails().getID(), existingPlayer);
+        PlayerStub newPlayer = new PlayerStub(/* connectionId= */ 2);
+        NettyRequest request = new NettyRequest("LOGIN", "testuser correctpassword");
+
+        new LOGIN().handle(newPlayer, request);
+
+        assertTrue(newPlayer.getDetails().isAuthenticated());
+        assertFalse(existingPlayer.getDetails().isAuthenticated());
+        assertTrue(existingPlayer.getNetworkStub().isClosed());
+    }
+
+    private void registerPlayer(String username, String password) {
+        playerDao.createPlayer(username, password,
+                /* email= */    username + "@test.com",
+                /* mission= */  "",
+                /* figure= */   "hd=180-1.ch=215-91.lg=695-91",
+                /* credits= */  0,
+                /* sex= */      "M",
+                /* birthday= */ "01-01-2000");
+    }
+
+    private static void setRoseauStaticField(String name, Object value) throws Exception {
+        Field field = Roseau.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+}

--- a/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/GameStub.java
+++ b/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/GameStub.java
@@ -1,0 +1,23 @@
+package org.alexdev.roseau.stubs;
+
+import org.alexdev.roseau.game.Game;
+import org.alexdev.roseau.game.player.PlayerManager;
+
+/**
+ * A stub {@link Game} that routes {@link #getPlayerManager()} to a provided {@link PlayerManager},
+ * allowing tests to control player lookups without a running game.
+ */
+public class GameStub extends Game {
+
+    private final PlayerManager playerManager;
+
+    public GameStub(PlayerManager playerManager) throws Exception {
+        super(/* dao= */ null);
+        this.playerManager = playerManager;
+    }
+
+    @Override
+    public PlayerManager getPlayerManager() {
+        return playerManager;
+    }
+}

--- a/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/InMemoryDaoStub.java
+++ b/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/InMemoryDaoStub.java
@@ -1,0 +1,68 @@
+package org.alexdev.roseau.stubs;
+
+import org.alexdev.roseau.dao.CatalogueDao;
+import org.alexdev.roseau.dao.Dao;
+import org.alexdev.roseau.dao.InventoryDao;
+import org.alexdev.roseau.dao.ItemDao;
+import org.alexdev.roseau.dao.MessengerDao;
+import org.alexdev.roseau.dao.NavigatorDao;
+import org.alexdev.roseau.dao.PlayerDao;
+import org.alexdev.roseau.dao.RoomDao;
+
+/**
+ * An in-memory stub {@link Dao} backed by an {@link InMemoryPlayerDaoStub}. All other DAOs throw
+ * {@link UnsupportedOperationException} for now.
+ */
+public class InMemoryDaoStub implements Dao {
+
+    private final InMemoryPlayerDaoStub playerDao;
+
+    public InMemoryDaoStub(InMemoryPlayerDaoStub playerDao) {
+        this.playerDao = playerDao;
+    }
+
+    @Override
+    public PlayerDao getPlayer() {
+        return playerDao;
+    }
+
+    @Override
+    public boolean connect() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isConnected() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public RoomDao getRoom() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ItemDao getItem() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CatalogueDao getCatalogue() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public InventoryDao getInventory() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public NavigatorDao getNavigator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MessengerDao getMessenger() {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/InMemoryPlayerDaoStub.java
+++ b/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/InMemoryPlayerDaoStub.java
@@ -1,0 +1,88 @@
+package org.alexdev.roseau.stubs;
+
+import org.alexdev.roseau.dao.PlayerDao;
+import org.alexdev.roseau.game.player.Permission;
+import org.alexdev.roseau.game.player.Player;
+import org.alexdev.roseau.game.player.PlayerDetails;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A {@link PlayerDao} that stores players in memory. To be used for testing purposes.
+ */
+public class InMemoryPlayerDaoStub implements PlayerDao {
+
+    private final Map<String, PlayerDetails> byUsername = new HashMap<>();
+    private int nextId = 1;
+
+    @Override
+    public void createPlayer(String username, String password, String email, String mission,
+                             String figure, int credits, String sex, String birthday) {
+        PlayerDetails details = new PlayerDetails(null);
+        details.fill(nextId++, username, mission, figure, /* poolFigure= */ "", email,
+                /* rank= */ 1, credits, sex, /* country= */ "", /* badge= */ "", birthday,
+                /* lastonline= */ 0L, /* personalGreeting= */ "", /* tickets= */ 0);
+        details.setPassword(password);
+        byUsername.put(username, details);
+    }
+
+    @Override
+    public boolean login(Player player, String username, String password) {
+        PlayerDetails stored = byUsername.get(username);
+        if (stored == null || !stored.getPassword().equals(password)) return false;
+        player.getDetails().fill(stored.getID(), stored.getName(), stored.getMission(),
+                stored.getFigure(), stored.getPoolFigure(), stored.getEmail(), stored.getRank(),
+                stored.getCredits(), stored.getSex(), stored.getCountry(), stored.getBadge(),
+                stored.getBirthday(), stored.getLastOnline(), stored.getPersonalGreeting(),
+                stored.getTickets());
+        return true;
+    }
+
+    @Override
+    public PlayerDetails getDetails(int userID) {
+        return byUsername.values().stream()
+                .filter(d -> d.getID() == userID)
+                .findFirst().orElse(null);
+    }
+
+    @Override
+    public PlayerDetails getDetails(String username) {
+        return byUsername.get(username);
+    }
+
+    @Override
+    public int getId(String username) {
+        PlayerDetails d = byUsername.get(username);
+        return d != null ? d.getID() : -1;
+    }
+
+    @Override
+    public boolean isNameTaken(String name) {
+        return byUsername.containsKey(name);
+    }
+
+    @Override
+    public void updatePlayer(PlayerDetails details) {
+        if (byUsername.containsKey(details.getName())) {
+            byUsername.put(details.getName(), details);
+        }
+    }
+
+    @Override
+    public void updateLastLogin(PlayerDetails details) {
+        PlayerDetails stored = byUsername.get(details.getName());
+        if (stored == null) return;
+        stored.fill(stored.getID(), stored.getName(), stored.getMission(), stored.getFigure(),
+                stored.getPoolFigure(), stored.getEmail(), stored.getRank(), stored.getCredits(),
+                stored.getSex(), stored.getCountry(), stored.getBadge(), stored.getBirthday(),
+                System.currentTimeMillis(), stored.getPersonalGreeting(), stored.getTickets());
+    }
+
+    @Override
+    public List<Permission> getPermissions() {
+        return Collections.emptyList();
+    }
+}

--- a/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/PlayerNetworkStub.java
+++ b/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/PlayerNetworkStub.java
@@ -1,0 +1,40 @@
+package org.alexdev.roseau.stubs;
+
+import com.google.common.collect.ImmutableList;
+import org.alexdev.roseau.messages.OutgoingMessageComposer;
+import org.alexdev.roseau.server.IPlayerNetwork;
+
+/**
+ * A stub {@link IPlayerNetwork} that tracks all responses sent to it, as well as whether the network has been closed.
+ */
+public class PlayerNetworkStub extends IPlayerNetwork {
+
+    private final ImmutableList.Builder<OutgoingMessageComposer> responses = ImmutableList.builder();
+    private boolean closed = false;
+
+    public PlayerNetworkStub() {
+        this(/* connectionId= */ 0, /* serverPort= */ 1000);
+    }
+
+    public PlayerNetworkStub(int connectionId, int serverPort) {
+        super(connectionId, serverPort);
+    }
+
+    @Override
+    public void send(OutgoingMessageComposer response) {
+        responses.add(response);
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+
+    public ImmutableList<OutgoingMessageComposer> getResponses() {
+        return responses.build();
+    }
+}

--- a/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/PlayerStub.java
+++ b/Roseau-Server/src/test/java/org/alexdev/roseau/stubs/PlayerStub.java
@@ -1,0 +1,35 @@
+package org.alexdev.roseau.stubs;
+
+import com.google.common.collect.ImmutableList;
+import org.alexdev.roseau.game.player.Player;
+import org.alexdev.roseau.messages.OutgoingMessageComposer;
+
+/**
+ * A stub {@link Player} backed by a {@link PlayerNetworkStub} that stores all responses sent to the player,
+ * accessible via {@link #getResponses}.
+ */
+public class PlayerStub extends Player {
+
+    private final PlayerNetworkStub networkStub;
+
+    public PlayerStub() {
+        this(new PlayerNetworkStub());
+    }
+
+    public PlayerStub(int connectionId) {
+        this(new PlayerNetworkStub(connectionId, /* serverPort= */ 1000));
+    }
+
+    private PlayerStub(PlayerNetworkStub networkStub) {
+        super(networkStub);
+        this.networkStub = networkStub;
+    }
+
+    public ImmutableList<OutgoingMessageComposer> getResponses() {
+        return networkStub.getResponses();
+    }
+
+    public PlayerNetworkStub getNetworkStub() {
+        return networkStub;
+    }
+}


### PR DESCRIPTION
Instead of closing user connection and making the user refresh the client, redirect to "Forgotten your password?" screen.

I assume this happens in the client [here](https://github.com/Quackster/habbo_src/blob/631d250a91b7372ce297ac9b163787a6b7100731/release5/hh_navigator/Cast%20External%20ParentScript%204%20-%20Navigator%20Handler%20Class.ls#L51)? I haven't found a way to show an incorrect password message and let the user try again without seeing the "Forgotten your password?" screen first, but this seems a bit better than closing the connection between the client and server in my opinion.

<img width="724" height="489" alt="image" src="https://github.com/user-attachments/assets/fce92213-9728-4bdb-8718-57e7d1bf4f6e" />

Also, I've implemented some testing stubs and adding unit tests for the LOGIN message class.